### PR TITLE
Display the right attributes for editing (mostly)

### DIFF
--- a/src/dialogs.py
+++ b/src/dialogs.py
@@ -186,6 +186,7 @@ class ObjAttrs:
                 new_val = AttrEdit(self.conn, attr, val).Show()
                 if new_val is not None and self.obj[attr] != new_val:
                     self.obj[attr] = new_val
+                UI.SetApplicationTitle(b'CN=%s Properties' % self.obj['cn'][-1])
         UI.CloseDialog()
         return ret
 

--- a/src/dialogs.py
+++ b/src/dialogs.py
@@ -115,6 +115,7 @@ class ObjAttrs:
         attrs.extend(rules['may'])
         for aux_class in rules['aux']:
             attrs.extend(self.__extend_attrs(aux_class))
+        attrs = [a for a in attrs if not a in self.conn.schema['constructedAttributes']]
         return attrs
 
     def __timestamp(self, val):


### PR DESCRIPTION
Follow DIT content rules and auxiliary classes. Also hide constructed attributes (MS adsi does this), and sort the attributes.